### PR TITLE
Make #flash_messages support Rails 4.1

### DIFF
--- a/lib/rails_utils.rb
+++ b/lib/rails_utils.rb
@@ -31,7 +31,7 @@ module RailsUtils
       html = ""
       flash.each do |key, message|
         html <<
-          content_tag(:div, class: "#{flash_class(key)} fade in") do
+          content_tag(:div, class: "#{flash_class(key.to_sym)} fade in") do
             content = ""
             content << content_tag(:button, "x", type: "button", class: "close", "data-dismiss" => "alert")
             content << message

--- a/test/rails_utils_test.rb
+++ b/test/rails_utils_test.rb
@@ -117,9 +117,12 @@ describe "RailsUtils::ActionViewExtensions" do
     [
       [ :success , /alert alert-success/, "flash is success" ],
       [ :notice  , /alert alert-info/   , "flash is notice"  ],
+      [ "notice" , /alert alert-info/   , "flash is notice"  ],
       [ :error   , /alert alert-error/  , "flash is error"   ],
       [ :alert   , /alert alert-error/  , "flash is alert"   ],
+      [ "alert"  , /alert alert-error/  , "flash is alert"   ],
       [ :custom  , /alert alert-custom/ , "flash is custom"  ],
+      [ "custom" , /alert alert-custom/ , "flash is custom"  ]
     ].each do |key, expected_class, expected_message|
       describe "when flash contains #{key} key" do
         before { set_flash key, expected_message }


### PR DESCRIPTION
Hi Winston, as flash keys in Rails 4.1 now normalised to string, could we convert the key into symbol before generating the flash class?

Please see: http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#flash-structure-changes

Thanks!
