### PR TITLE
Add button_html and button_class options for "flash_messages"

### DIFF
--- a/lib/rails_utils.rb
+++ b/lib/rails_utils.rb
@@ -37,7 +37,7 @@ module RailsUtils
       flash.collect do |key, message|
         next if message.blank?
 
-        content_tag(:div, content_tag(:button, "x", type: "button", class: "close", "data-dismiss" => "alert") + message, class: "#{flash_class(key)} fade in #{options[:class]}")
+        content_tag(:div, content_tag(:button, options[:button_html] || "x", type: "button", class: options[:button_class] || "close", "data-dismiss" => "alert") + message, class: "#{flash_class(key)} fade in #{options[:class]}")
       end.join("\n").html_safe
     end
 

--- a/test/rails_utils_test.rb
+++ b/test/rails_utils_test.rb
@@ -191,5 +191,20 @@ describe "RailsUtils::ActionViewExtensions" do
         view.flash_messages.must_match /data-dismiss=.*alert/
       end
     end
+
+    describe "options" do
+      it "can allow override of button content (default 'x')" do
+        set_flash :alert, "not important"
+        view.flash_messages.must_match %r{>x</button>}
+        view.flash_messages(button_html: '').must_match %r{button class="close"}
+      end
+
+      it "can allow override of button css class (default 'close')" do
+        set_flash :alert, "not important"
+        view.flash_messages.must_match %r{>x</button>}
+        view.flash_messages(button_class: 'abc def').must_match %r{button class="abc def"}
+      end
+    end
+
   end
 end


### PR DESCRIPTION
useful when templates has `x` better styled, e.g.

``` slim
= flash_messages
```

![screen shot 2014-11-05 at 12 31 11 pm](https://cloud.githubusercontent.com/assets/473/4912816/9b2b3d12-64a4-11e4-8e88-d78420b2b253.png)

``` slim
= flash_messages(button_class: 'close fui-cross', button_html: '')
```

![screen shot 2014-11-05 at 12 30 23 pm](https://cloud.githubusercontent.com/assets/473/4912812/835da080-64a4-11e4-9cc2-d43167f3cc83.png)
