### PR TITLE
Fix #winston/rails_utils/7 do not render flash[:timedout]

### DIFF
--- a/lib/rails_utils.rb
+++ b/lib/rails_utils.rb
@@ -36,6 +36,7 @@ module RailsUtils
     def flash_messages(options = {})
       flash.collect do |key, message|
         next if message.blank?
+        next if key.to_s == 'timedout'
 
         content_tag(:div, content_tag(:button, options[:button_html] || "x", type: "button", class: options[:button_class] || "close", "data-dismiss" => "alert") + message, class: "#{flash_class(key)} fade in #{options[:class]}")
       end.join("\n").html_safe

--- a/test/rails_utils_test.rb
+++ b/test/rails_utils_test.rb
@@ -206,5 +206,10 @@ describe "RailsUtils::ActionViewExtensions" do
       end
     end
 
+    it "should skip flash[:timedout]" do
+      set_flash :timedout, "not important"
+      view.flash_messages.must_equal ""
+    end
+
   end
 end


### PR DESCRIPTION
Fix #7 by skipping `key.to_s == 'timedout'`
