### PR TITLE
`page_title` should prefer to use `:default` provided by gem user

### DIFF
--- a/lib/rails_utils.rb
+++ b/lib/rails_utils.rb
@@ -17,7 +17,7 @@ module RailsUtils
 
     def page_title(options={})
       default_page_title = "#{page_controller_class.capitalize} #{page_action_class.capitalize}"
-      i18n_options = { default: default_page_title }.reverse_merge!(options)
+      i18n_options = { default: default_page_title }.merge!(options)
       I18n.t("#{page_controller_class}.#{page_action_class}.title", i18n_options)
     end
 

--- a/test/rails_utils_test.rb
+++ b/test/rails_utils_test.rb
@@ -85,6 +85,10 @@ describe "RailsUtils::ActionViewExtensions" do
       it "combines page_controller_class and page_action_class" do
         view.page_title.must_equal default_translation
       end
+
+      it "uses :default provided by gem user" do
+        view.page_title(default: 'my custom default').must_equal 'my custom default'
+      end
     end
 
     describe 'when translation is available' do


### PR DESCRIPTION
no point disallowing default override
