### PR TITLE
Add proper "at_least_one" validation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    sqlite3 (1.3.10)
     thor (0.19.1)
     thread_safe (0.3.3)
     tilt (1.4.1)
@@ -90,4 +91,5 @@ DEPENDENCIES
   minitest (~> 4.7.5)
   mocha (~> 0.14.0)
   rails_utils!
+  sqlite3
   turn (~> 0.9.6)

--- a/lib/at_least_one_validator.rb
+++ b/lib/at_least_one_validator.rb
@@ -1,0 +1,9 @@
+class AtLeastOneValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value.detect {|x| x.valid? && !x.marked_for_destruction? }
+      # found at least 1 child valid and NOT marked_for_destruction
+    else
+      record.errors.add(attribute, options[:message] || I18n.t('errors.messages.blank')) # need error on self to halt :save
+    end
+  end
+end

--- a/lib/rails_utils.rb
+++ b/lib/rails_utils.rb
@@ -1,4 +1,5 @@
 require 'action_view'
+require 'at_least_one_validator'
 
 module RailsUtils
   module ActionViewExtensions

--- a/rails_utils.gemspec
+++ b/rails_utils.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest" , "~> 4.7.5"
   s.add_development_dependency "turn"     , "~> 0.9.6"
   s.add_development_dependency "mocha"    , "~> 0.14.0"
+  s.add_development_dependency "sqlite3"
 
   s.license = 'MIT'
 end

--- a/test/at_least_one_validator_test.rb
+++ b/test/at_least_one_validator_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+describe "RailsUtils::Validators" do
+
+  class Photo < ActiveRecord::Base; end
+  class Album < ActiveRecord::Base
+    has_many :photos
+    validates :photos, at_least_one: true
+  end
+
+  before(:all) do
+    ActiveRecord::Base.connection.create_table "albums", force: true do |t|
+      t.datetime "created_at"
+      t.datetime "updated_at"
+    end
+
+    ActiveRecord::Base.connection.create_table "photos", force: true do |t|
+      t.integer  "album_id"
+      t.datetime "created_at"
+      t.datetime "updated_at"
+    end
+  end
+
+  describe '#at_least_one' do
+    it 'should require at least 1 valid child' do
+      album = Album.new
+      assert_includes album.tap(&:valid?).errors.keys, :photos
+      album.photos << Photo.new
+      refute_includes album.tap(&:valid?).errors.keys, :photos
+    end
+
+    it 'cannot delete the last child' do
+      album = Album.new(photos: [Photo.new])
+      refute_includes album.tap(&:valid?).errors.keys, :photos
+      album.photos.first.mark_for_destruction
+      assert_includes album.tap(&:valid?).errors.keys, :photos
+    end
+  end
+end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 # Pick the frameworks you want:
-# require "active_record/railtie"
+require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
 # require "sprockets/railtie"

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -1,0 +1,3 @@
+test:
+  adapter: sqlite3
+  database: ":memory:"

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -32,4 +32,6 @@ Dummy::Application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  config.eager_load = false
 end


### PR DESCRIPTION
- `marked_for_destruction` is needed to catch "accepts_nested_attributes_for allow_destroy: true"
- test isolates existence of `errors.keys` instead of worrying about entire model being valid (unnecessary fixture setup)
- detect for at least one `valid?` and `not marked_for_destruction?`

Sample

``` ruby
class Photo < ActiveRecord::Base
end

class Album < ActiveRecord::Base
  has_many :photos
  validates :photos, at_least_one: true
end
```

related https://github.com/rails/rails/issues/3961
