### PR TITLE
Add config to choose between underscored or hyphenated class names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ You can also:
 - Add additional CSS classes to the alert with the `class` option.
 - Customize the close button with `button_html` and `button_class` options.
 
+## Configuration
+
+Override any of these defaults in `config/initializers/rails_utils.rb`
+
+```ruby
+RailsUtils.configure do |config|
+  config.selector_format = :underscored # or hyphenated
+end
+```
+
 ## Contributing
 
 Pull Requests are very welcomed (with specs, of course)!

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Override any of these defaults in `config/initializers/rails_utils.rb`
 
 ```ruby
 RailsUtils.configure do |config|
-  config.selector_format = :underscored # or hyphenated
+  config.selector_format = :underscored # or :hyphenated
 end
 ```
 

--- a/lib/rails_utils.rb
+++ b/lib/rails_utils.rb
@@ -1,8 +1,24 @@
+require 'rails_utils/configuration'
 require 'action_view'
 
 module RailsUtils
   module ActionViewExtensions
     def page_controller_class
+      case RailsUtils.configuration.selector_format
+      when :underscored
+        page_controller_class_underscored
+      when :hyphenated
+        page_controller_class_hyphenated
+      else
+        page_controller_class_underscored
+      end
+    end
+
+    def page_controller_class_hyphenated
+      page_controller_class_underscored.dasherize
+    end
+
+    def page_controller_class_underscored
       controller.class.to_s.sub(/Controller$/, "").underscore.sub(/\//, "_")
     end
 
@@ -26,9 +42,9 @@ module RailsUtils
 
       javascript_tag <<-JS
         #{application_name}.init();
-        if(#{application_name}.#{page_controller_class}) {
-          if(#{application_name}.#{page_controller_class}.init) { #{application_name}.#{page_controller_class}.init(); }
-          if(#{application_name}.#{page_controller_class}.init_#{page_action_class}) { #{application_name}.#{page_controller_class}.init_#{page_action_class}(); }
+        if(#{application_name}.#{page_controller_class_underscored}) {
+          if(#{application_name}.#{page_controller_class_underscored}.init) { #{application_name}.#{page_controller_class_underscored}.init(); }
+          if(#{application_name}.#{page_controller_class_underscored}.init_#{page_action_class}) { #{application_name}.#{page_controller_class_underscored}.init_#{page_action_class}(); }
         }
       JS
     end

--- a/lib/rails_utils/configuration.rb
+++ b/lib/rails_utils/configuration.rb
@@ -1,0 +1,17 @@
+module RailsUtils
+  class Configuration
+    attr_accessor :selector_format
+
+    def initialize
+      @selector_format = :underscored
+    end
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield configuration
+  end
+end

--- a/test/rails_utils_test.rb
+++ b/test/rails_utils_test.rb
@@ -32,6 +32,23 @@ describe "RailsUtils::ActionViewExtensions" do
         view.page_controller_class.must_equal controller_name
       end
     end
+
+    describe "simple controller with hyphenated selector format" do
+      let(:controller_class) { "Awesome::AnimeController" }
+      let(:controller_name)  { "awesome-anime" }
+
+      before do
+        RailsUtils.configure do |config|
+          config.selector_format = :hyphenated
+        end
+
+        controller.stubs(:class).returns(controller_class)
+      end
+
+      it "returns controller name" do
+        view.page_controller_class.must_equal controller_name
+      end
+    end
   end
 
   describe "#page_action_class" do


### PR DESCRIPTION
![lol](http://hosted.akibraun.com/g/catgifpage34.gif)

scss-lint prefers hyphenated selectors by [default](https://github.com/causes/scss-lint/blob/master/config/default.yml#L86). It is also recommended by [sass](http://sass-lang.com/styleguide/code) to use hyphenated selectors. We should allow users to choose whether they want hyphenated or underscored selectors. 