### PR TITLE
Update dummy app environment configs.

### DIFF
--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -6,9 +6,6 @@ Dummy::Application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
-  # Log error messages when you accidentally call methods on nil.
-  config.whiny_nils = true
-
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
@@ -22,10 +19,12 @@ Dummy::Application.configure do
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
 
-
   # Do not compress assets
   config.assets.compress = false
 
   # Expands the lines which load the assets
   config.assets.debug = true
+
+  # Do not eager load code on boot.
+  config.eager_load = false
 end

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -61,4 +61,6 @@ Dummy::Application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
+  # Do not eager load code on boot.
+  config.eager_load = true
 end

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -11,9 +11,6 @@ Dummy::Application.configure do
   config.serve_static_assets = true
   config.static_cache_control = "public, max-age=3600"
 
-  # Log error messages when you accidentally call methods on nil
-  config.whiny_nils = true
-
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
@@ -29,7 +26,9 @@ Dummy::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  # Do not eager load code on boot.
+  config.eager_load = false
 end


### PR DESCRIPTION
- Remove deprecated whiny_nils configs.

  ```
  $ bundle exec rake
  DEPRECATION WARNING: config.whiny_nils option is deprecated and no longer works. (called from block in <top (required)> at /Users/Juan/dev/rails_utils/test/dummy/config/environments/test.rb:15)
  config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

    * development - set it to false
    * test - set it to false (unless you use a tool that preloads your test environment)
    * production - set it to true
  ```

- Add eager_load configs.

  ```
  $ bundle exec rake
  config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

    * development - set it to false
    * test - set it to false (unless you use a tool that preloads your test environment)
    * production - set it to true
  ```