### PR TITLE
Using `gsub` instead of `sub`

### DIFF
--- a/lib/rails_utils.rb
+++ b/lib/rails_utils.rb
@@ -78,7 +78,7 @@ module RailsUtils
       end
 
       def page_controller_class_underscored
-        controller.class.to_s.sub(/Controller$/, "").underscore.sub(/\//, "_")
+        controller.class.to_s.sub(/Controller$/, "").underscore.gsub(/\//, "_")
       end
   end
 end

--- a/test/rails_utils_test.rb
+++ b/test/rails_utils_test.rb
@@ -23,8 +23,8 @@ describe "RailsUtils::ActionViewExtensions" do
     end
 
     describe "simple controller" do
-      let(:controller_class) { "Awesome::AnimeController" }
-      let(:controller_name)  { "awesome_anime" }
+      let(:controller_class) { "Super::Awesome::AnimeController" }
+      let(:controller_name)  { "super_awesome_anime" }
 
       before { controller.stubs(:class).returns(controller_class) }
 


### PR DESCRIPTION
Currently if I have a `Super::Awesome::AnimeController`, the generated class name will be `super/awesome_anime`, which is not correct I think.