### PR TITLE
Cache `page_title` result to allow for

### DIFF
--- a/lib/rails_utils.rb
+++ b/lib/rails_utils.rb
@@ -22,9 +22,11 @@ module RailsUtils
     end
 
     def page_title(options={})
-      default_page_title = "#{page_controller_class.capitalize} #{page_action_class.capitalize}"
-      i18n_options = { default: default_page_title }.merge!(options)
-      I18n.t("#{page_controller_class}.#{page_action_class}.title", i18n_options)
+      @page_title ||= begin
+        default_page_title = "#{page_controller_class.capitalize} #{page_action_class.capitalize}"
+        i18n_options = { default: default_page_title }.merge!(options)
+        I18n.t("#{page_controller_class}.#{page_action_class}.title", i18n_options)
+      end
     end
 
     def javascript_initialization(options = {})

--- a/test/rails_utils_test.rb
+++ b/test/rails_utils_test.rb
@@ -123,6 +123,11 @@ describe "RailsUtils::ActionViewExtensions" do
       it "uses :default provided by gem user" do
         view.page_title(default: 'my custom default').must_equal 'my custom default'
       end
+
+      it "calling multiple times reuses first result (template renders before layout)" do
+        view.page_title(default: 'my custom default').must_equal 'my custom default'
+        view.page_title.must_equal 'my custom default'
+      end
     end
 
     describe 'when translation is available' do


### PR DESCRIPTION
- customization of page_title in controller action template
- AND simply calling "page_title" in layout template to reuse the generated page_title value
