### PR TITLE
Changed JS methods to be scoped by name of controller action

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ When application is MyApp, and controller/action is `animes#show`, `javascript_i
             MyApp.init();
             if(MyApp.animes) {
               if(MyApp.animes.init) { MyApp.animes.init(); }
-              if(MyApp.animes.init_show) { MyApp.animes.init_show(); }
+              if(MyApp.animes.show && MyApp.animes.show.init) { MyApp.animes.show.init(); }
             }
     //]]>
     </script>

--- a/lib/rails_utils.rb
+++ b/lib/rails_utils.rb
@@ -36,14 +36,14 @@ module RailsUtils
 
       if content_for?(:js_init_method)
         js_custom_name = content_for(:js_init_method)
-        custom_js_init_method = "if(#{application_name}.#{js_namespace_name}.init_#{js_custom_name}) { #{application_name}.#{js_namespace_name}.init_#{js_custom_name}(); }"
+        custom_js_init_method = "if(#{application_name}.#{js_namespace_name}.#{js_custom_name}.init) { #{application_name}.#{js_namespace_name}.#{js_custom_name}.init(); }"
       end
 
       javascript_tag <<-JS
         #{application_name}.init();
         if(#{application_name}.#{js_namespace_name}) {
           if(#{application_name}.#{js_namespace_name}.init) { #{application_name}.#{js_namespace_name}.init(); }
-          if(#{application_name}.#{js_namespace_name}.init_#{js_function_name}) { #{application_name}.#{js_namespace_name}.init_#{js_function_name}(); }
+          if(#{application_name}.#{js_namespace_name}.#{js_function_name} && #{application_name}.#{js_namespace_name}.#{js_function_name}.init) { #{application_name}.#{js_namespace_name}.#{js_function_name}.init(); }
           #{custom_js_init_method}
         }
       JS

--- a/test/rails_utils_test.rb
+++ b/test/rails_utils_test.rb
@@ -169,7 +169,7 @@ describe "RailsUtils::ActionViewExtensions" do
 
       it "invokes controller and action javascript" do
         view.javascript_initialization.must_match "Dummy.#{controller_name}.init();"
-        view.javascript_initialization.must_match "Dummy.#{controller_name}.init_#{action_name}();"
+        view.javascript_initialization.must_match "Dummy.#{controller_name}.#{action_name}.init();"
       end
     end
 
@@ -177,7 +177,7 @@ describe "RailsUtils::ActionViewExtensions" do
       let(:action_name) { "create" }
 
       it "replaces create with new" do
-        view.javascript_initialization.must_match "Dummy.#{controller_name}.init_new();"
+        view.javascript_initialization.must_match "Dummy.#{controller_name}.new.init();"
       end
     end
 
@@ -185,7 +185,7 @@ describe "RailsUtils::ActionViewExtensions" do
       let(:action_name) { "update" }
 
       it "replaces update with create" do
-        view.javascript_initialization.must_match "Dummy.#{controller_name}.init_edit();"
+        view.javascript_initialization.must_match "Dummy.#{controller_name}.edit.init();"
       end
     end
 
@@ -194,7 +194,7 @@ describe "RailsUtils::ActionViewExtensions" do
 
       it "uses the custom js init method" do
         view.content_for(:js_init_method) { "custom" }
-        view.javascript_initialization.must_match "Dummy.#{controller_name}.init_custom();"
+        view.javascript_initialization.must_match "Dummy.#{controller_name}.custom.init();"
       end
     end
 
@@ -202,7 +202,7 @@ describe "RailsUtils::ActionViewExtensions" do
       let(:action_name) { "update" }
 
       it "does not generate an additional javascript method" do
-        view.javascript_initialization.wont_match "Dummy.#{controller_name}.init_();"
+        view.javascript_initialization.wont_match "Dummy.#{controller_name}..init();"
       end
     end
   end


### PR DESCRIPTION
Changed the way javascript methods are generated so that it is scoped by the name of controller action. This is so that 2 actions can have methods with the same name and not conflict with each other.

For example:
```
<script type="text/javascript">
//<![CDATA[
        MyApp.init();
        if(MyApp.animes) {
          if(MyApp.animes.init) { MyApp.animes.init(); }
          if(MyApp.animes.show && MyApp.animes.show.init) { MyApp.animes.show.init(); }
        }
//]]>
</script>
<script>
        MyApp.animes.show = {
                same_name_method: function() { ... }
        };
        MyApp.animes.index = {
                same_name_method: function() { ... }
        };
</script>
```