### PR TITLE
Fix potential XSS in flash messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- [Pull Request 30](https://github.com/winston/rails_utils/pull/30) - Sanitize flash messages - by @fonglh.
+
 ### Version 4.0.0
 
 - [Pull Request 28](https://github.com/winston/rails_utils/pull/28) - [Development] remove `.ruby-version` file - by @JuanitoFatas

--- a/lib/rails_utils.rb
+++ b/lib/rails_utils.rb
@@ -51,12 +51,12 @@ module RailsUtils
       JS
     end
 
-    def flash_messages(options = {})
+    def flash_messages(options = {}, sanitizer_options = {})
       flash.collect do |key, message|
         next if message.blank?
         next if key.to_s == "timedout"
 
-        content_tag(:div, content_tag(:button, options[:button_html] || "x", type: "button", class: options[:button_class] || "close", "data-dismiss" => "alert") + message.html_safe, class: "#{flash_class(key)} fade in #{options[:class]}")
+        content_tag(:div, content_tag(:button, options[:button_html] || "x", type: "button", class: options[:button_class] || "close", "data-dismiss" => "alert") + sanitize(message, sanitizer_options), class: "#{flash_class(key)} fade in #{options[:class]}")
       end.join("\n").html_safe
     end
 

--- a/rails_utils.gemspec
+++ b/rails_utils.gemspec
@@ -15,14 +15,10 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", ">= 3.2"
+  s.add_dependency "rails", ">=3.2", "<= 5.2.2"
 
-  # Attempted to upgrade minitest to v5.0.6 on 22 Aug. Failed because turn v0.9.6 has a mismatched adapter to minitest v5.0.6
-  # https://github.com/TwP/turn/issues/122
-
-  s.add_development_dependency "minitest" , "~> 4.7.5"
-  s.add_development_dependency "turn"     , "~> 0.9.6"
-  s.add_development_dependency "mocha"    , "~> 0.14.0"
+  s.add_development_dependency "minitest" , ">= 4.7.5"
+  s.add_development_dependency "mocha"
 
   s.license = 'MIT'
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -4,7 +4,7 @@ require File.expand_path('../boot', __FILE__)
 # require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
-# require "sprockets/railtie"
+require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
 Bundler.require(*Rails.groups)

--- a/test/rails_utils_test.rb
+++ b/test/rails_utils_test.rb
@@ -266,6 +266,24 @@ describe "RailsUtils::ActionViewExtensions" do
       end
     end
 
+    describe "sanitizer_options" do
+      it "can allow sanitizer options like tags" do
+        set_flash :alert, "<script>dangerous</script>"
+        view.flash_messages({}, { tags: ['script'] }).must_match "<script>dangerous</script>"
+      end
+    end
+
+    it "should strip <script> tags by default" do
+      set_flash :alert, "<script>alert('XSS')</script>"
+      view.flash_messages.wont_match "<script>alert('XSS')<script>"
+      view.flash_messages.must_match "alert('XSS')"
+    end
+
+    it "should preserve anchor links by default" do
+      set_flash :alert, "<a href=\"https://example.org\">example page</a>"
+      view.flash_messages.must_match "<a href=\"https://example.org\">example page</a>"
+    end
+
     it "should skip flash[:timedout]" do
       set_flash :timedout, "not important"
       view.flash_messages.must_equal ""
@@ -275,18 +293,6 @@ describe "RailsUtils::ActionViewExtensions" do
       set_flash :alert, "not important"
 
       view.flash_messages.html_safe?.must_equal true
-    end
-
-    it "each message of flash should call html_safe" do
-      set_flash :alert, Minitest::Mock.new
-
-      view.flash.instance_variable_get(:@flashes).values.each do |message|
-        message.expect :blank?, false
-        message.expect :html_safe, "test"
-        message.expect :html_safe?, true
-      end
-
-      view.flash_messages.must_equal "<div class=\"alert alert-danger alert-error fade in \"><button type=\"button\" class=\"close\" data-dismiss=\"alert\">x</button>test</div>"
     end
   end
 end

--- a/test/rails_utils_test.rb
+++ b/test/rails_utils_test.rb
@@ -243,12 +243,12 @@ describe "RailsUtils::ActionViewExtensions" do
     describe "when bootstrap is present" do
       it "can fade in and out" do
         set_flash :alert, "not important"
-        view.flash_messages.must_match /fade in/
+        view.flash_messages.must_match(/fade in/)
       end
 
       it "can be dismissed" do
         set_flash :alert, "not important"
-        view.flash_messages.must_match /data-dismiss=.*alert/
+        view.flash_messages.must_match(/data-dismiss=.*alert/)
       end
     end
 
@@ -256,13 +256,13 @@ describe "RailsUtils::ActionViewExtensions" do
       it "can allow override of button content (default 'x')" do
         set_flash :alert, "not important"
         view.flash_messages.must_match %r{>x</button>}
-        view.flash_messages(button_html: '').must_match %r{button class="close"}
+        view.flash_messages(button_html: '').must_match %r{button type="button" class="close"}
       end
 
       it "can allow override of button css class (default 'close')" do
         set_flash :alert, "not important"
         view.flash_messages.must_match %r{>x</button>}
-        view.flash_messages(button_class: 'abc def').must_match %r{button class="abc def"}
+        view.flash_messages(button_class: 'abc def').must_match %r{button type="button" class="abc def"}
       end
     end
 
@@ -280,13 +280,13 @@ describe "RailsUtils::ActionViewExtensions" do
     it "each message of flash should call html_safe" do
       set_flash :alert, Minitest::Mock.new
 
-      messages = view.flash.instance_variable_get(:@flashes).values.each do |message|
+      view.flash.instance_variable_get(:@flashes).values.each do |message|
         message.expect :blank?, false
         message.expect :html_safe, "test"
         message.expect :html_safe?, true
       end
 
-      view.flash_messages.must_equal "<div class=\"alert alert-danger alert-error fade in \"><button class=\"close\" data-dismiss=\"alert\" type=\"button\">x</button>test</div>"
+      view.flash_messages.must_equal "<div class=\"alert alert-danger alert-error fade in \"><button type=\"button\" class=\"close\" data-dismiss=\"alert\">x</button>test</div>"
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,11 +3,7 @@ ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require 'minitest/autorun'
-begin
-  require 'turn/autorun'
-rescue LoadError
-  puts 'You must `gem install turn` and `bundle install` to run tests with turn'
-end
+require 'mocha/minitest'
 
 Rails.backtrace_cleaner.remove_silencers!
 


### PR DESCRIPTION
Sanitize flash messages with the Rails sanitizer. The default `Rails::Html::WhiteListSanitizer` allows anchor links (see https://github.com/rails/rails-html-sanitizer/blob/master/lib/rails/html/sanitizer.rb#L108), which preserves the intent behind #22 and #23 of allowing anchor links.